### PR TITLE
bump version, minor label fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM alpine:3.6
 
-MAINTAINER cavemandaveman <cavemandaveman@protonmail.com>
+LABEL maintainer="cavemandaveman <cavemandaveman@protonmail.com>"
 
 ENV SONATYPE_DIR="/opt/sonatype"
-ENV NEXUS_VERSION="3.6.0-02" \
+ENV NEXUS_VERSION="3.7.1-02" \
     NEXUS_HOME="${SONATYPE_DIR}/nexus" \
     NEXUS_DATA="/nexus-data" \
     SONATYPE_WORK=${SONATYPE_DIR}/sonatype-work \


### PR DESCRIPTION
MAINTAINER is deprecated as of docker 1.13 in favour of label.
i bumped the nexus version to the latest from the website