### PR TITLE
Update to 3.13.0-01

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.6
 LABEL maintainer="cavemandaveman <cavemandaveman@protonmail.com>"
 
 ENV SONATYPE_DIR="/opt/sonatype"
-ENV NEXUS_VERSION="3.12.1-01" \
+ENV NEXUS_VERSION="3.13.0-01" \
     NEXUS_HOME="${SONATYPE_DIR}/nexus" \
     NEXUS_DATA="/nexus-data" \
     SONATYPE_WORK=${SONATYPE_DIR}/sonatype-work \


### PR DESCRIPTION
New version of Nexus came out on 2018-07-19 and `Nexus Platform Plugin` already works with it. New version has API changes and `3.12` is not compatible with updated plugin.